### PR TITLE
feat(cookie): use base64url encoding for cookie value

### DIFF
--- a/src/set-cookie/serialize/index.js
+++ b/src/set-cookie/serialize/index.js
@@ -1,4 +1,4 @@
-import cookieValueStrictPercentEncoder from './encoders/cookie-value-strict-percent.js';
+import cookieValueStrictBase64urlEncoder from './encoders/cookie-value-strict-base64url.js';
 import cookieNameStrictValidator from './validators/cookie-name-strict.js';
 import cookieValueStrictValidator from './validators/cookie-value-strict.js';
 import { identity } from '../../utils.js';
@@ -6,7 +6,7 @@ import { identity } from '../../utils.js';
 const defaultOptions = {
   encoders: {
     name: identity,
-    value: cookieValueStrictPercentEncoder,
+    value: cookieValueStrictBase64urlEncoder,
   },
   validators: {
     name: cookieNameStrictValidator,

--- a/test/cookie/serialize.js
+++ b/test/cookie/serialize.js
@@ -13,6 +13,7 @@ describe('serializeCookie', function () {
   it('should serialize object', function () {
     assert.strictEqual(serializeCookie({ foo: 'bar' }), 'foo=bar');
     assert.strictEqual(serializeCookie({ foo: 'bar', baz: 'raz' }), 'foo=bar; baz=raz');
+    assert.strictEqual(serializeCookie({ foo: ';' }), 'foo=Ow'); // base64url encoding
     assert.strictEqual(serializeCookie({}), '');
   });
 


### PR DESCRIPTION
BREAKING CHANGE: use base64url encoding for cookie value. Before percent encoding was used.